### PR TITLE
Historical tests

### DIFF
--- a/CurrencyExchange.Services/CurrencyExchangeService.cs
+++ b/CurrencyExchange.Services/CurrencyExchangeService.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
+using System.Globalization;
 
 namespace CurrencyExchange.Services
 {
@@ -16,16 +17,21 @@ namespace CurrencyExchange.Services
             this.client = client;
         }
 
-        public async Task<ExchangeData> GetExchangeDataAsync (double initialAmount, CurrencyType initialType, CurrencyType returnType)
+        public async Task<ExchangeData> GetExchangeDataAsync (double initialAmount, CurrencyType initialType, CurrencyType returnType, DateTime? chosenDate = null )
         {
-            var stringResponse = await client.GetStringAsync($"https://api.exchangeratesapi.io/latest?base={initialType}&symbols={returnType}");
+            string dateString = chosenDate.HasValue ? chosenDate.Value.ToString("yyyy-MM-dd") : null;
+            string url = chosenDate.HasValue
+                ? $"https://api.exchangeratesapi.io/{dateString}?base={initialType}&symbols={returnType}"
+                : $"https://api.exchangeratesapi.io/latest?base={initialType}&symbols={returnType}";
+            var stringResponse = await client.GetStringAsync(url);
             var exchangeModel = JsonConvert.DeserializeObject<ExchangeModel>(stringResponse);
             var exchangeData = new ExchangeData
             {
                 InitialAmount = initialAmount,
                 InitialCurrency = initialType,
                 ReturnCurrency = returnType,
-                ReturnAmount = exchangeModel.Rates[returnType.ToString()]
+                ReturnAmount = exchangeModel.Rates[returnType.ToString()],
+                Date = exchangeModel.Date,
             };
             return exchangeData;
         }

--- a/CurrencyExchange.Services/ExchangeData.cs
+++ b/CurrencyExchange.Services/ExchangeData.cs
@@ -18,5 +18,6 @@ namespace CurrencyExchange
                 return (InitialAmount * ReturnAmount);
             }
         }
+        public DateTime Date { get; set; }
     }
 }

--- a/CurrencyExchange.Services/ICurrencyExchangeService.cs
+++ b/CurrencyExchange.Services/ICurrencyExchangeService.cs
@@ -1,9 +1,10 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 
 namespace CurrencyExchange.Services
 {
     public interface ICurrencyExchangeService
     {
-        Task<ExchangeData> GetExchangeDataAsync(double initialAmount, CurrencyType initialType, CurrencyType returnType);
+        Task<ExchangeData> GetExchangeDataAsync(double initialAmount, CurrencyType initialType, CurrencyType returnType, DateTime? date = null);
     }
 }

--- a/CurrencyExchange.Test/HistoricalUnitTests.cs
+++ b/CurrencyExchange.Test/HistoricalUnitTests.cs
@@ -1,0 +1,26 @@
+﻿using CurrencyExchange.Services;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CurrencyExchange.Test
+{
+    [TestClass]
+    public class HistoricalUnitTests
+    {
+        [TestMethod]
+        public async Task ExchangeModel_Returns_Correct_Date()
+        {
+            var client = new HttpClient();
+            var exchangeService = new CurrencyExchangeService(client);
+            var expected = new DateTime(2014, 6, 6);
+
+            var exchangeData = await exchangeService.GetExchangeDataAsync(1, CurrencyType.USD, CurrencyType.GBP, expected);
+
+            Assert.AreEqual(expected, exchangeData.Date);
+        }
+    }
+}

--- a/CurrencyExchange.Test/LatestUnitTests.cs
+++ b/CurrencyExchange.Test/LatestUnitTests.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 namespace CurrencyExchange.Test
 {
     [TestClass]
-    public class UnitTests
+    public class LatestUnitTests
     {
         [TestMethod]
         public void CurrencyInfoStatic_Returns_Correct_CurrencyInfo()

--- a/CurrencyExchange/IndexViewModel.cs
+++ b/CurrencyExchange/IndexViewModel.cs
@@ -10,5 +10,6 @@ namespace CurrencyExchange
         public CurrencyType InitialType { get; set; }
         public double InitialAmount { get; set; }
         public CurrencyType ReturnType { get; set; }
+        public DateTime? Date { get; set; }
     }
 }

--- a/CurrencyExchange/Pages/Convert.cshtml
+++ b/CurrencyExchange/Pages/Convert.cshtml
@@ -4,10 +4,13 @@
     ViewData["Title"] = "Convert";
 }
 
-<h2>Latest Exchange Rate</h2>
+<h2>Exchange Rates</h2>
 
 <div id="results">
     <ul class="list-group">
+        @if (Model.ExchangeData.Date != null) {
+            <li class="list-group-item"><b>Date: </b>@Model.ExchangeData.Date.ToLongDateString()</li>
+        }
         <li class="list-group-item"><b>Base Currency: </b>@Model.InitialCurrencyInfo.Name</li>
         <li class="list-group-item"><b>Requested Amount: </b>@Model.InitialCurrencyInfo.Symbol@Model.ExchangeData.InitialAmount</li>
         <li class="list-group-item"><b>Converted To: </b>@Model.ReturnCurrencyInfo.Name</li>

--- a/CurrencyExchange/Pages/Convert.cshtml
+++ b/CurrencyExchange/Pages/Convert.cshtml
@@ -8,9 +8,7 @@
 
 <div id="results">
     <ul class="list-group">
-        @if (Model.ExchangeData.Date != null) {
-            <li class="list-group-item"><b>Date: </b>@Model.ExchangeData.Date.ToLongDateString()</li>
-        }
+        <li class="list-group-item"><b>Date: </b>@Model.ExchangeData.Date.ToLongDateString()</li>
         <li class="list-group-item"><b>Base Currency: </b>@Model.InitialCurrencyInfo.Name</li>
         <li class="list-group-item"><b>Requested Amount: </b>@Model.InitialCurrencyInfo.Symbol@Model.ExchangeData.InitialAmount</li>
         <li class="list-group-item"><b>Converted To: </b>@Model.ReturnCurrencyInfo.Name</li>

--- a/CurrencyExchange/Pages/Index.cshtml
+++ b/CurrencyExchange/Pages/Index.cshtml
@@ -11,48 +11,10 @@
 <div class="card">
     <div class="card-body">
         <form id="latest-data" method="post" class="text-center">
-            <fieldset>
-                <legend><b>Get the latest exchange rates</b></legend>
-                <div class="form-group">
-                    <h5>Initial currency type:</h5>
-                    <select class="select-one" required asp-for="IndexViewModel.InitialType">
-                        <optgroup label="Initial Currency">
-                            <option value="EUR">€ Euro</option>
-                            <option value="USD">$ U.S. Dollar</option>
-                            <option value="GBP">£ Pound Sterling</option>
-                        </optgroup>
-                    </select>
-                </div>
-                <div class="form-group">
-                    <h5>Amount to convert:</h5>
-                    <input type="number" required asp-for="IndexViewModel.InitialAmount" min="0.01" step="0.01" />
-                </div>
-                <div class="form-group">
-                    <h5>Return currency type:</h5>
-                    <select class="select-two" required asp-for="IndexViewModel.ReturnType">
-                        <optgroup label="Return Currency">
-                            <option value="EUR">€ Euro</option>
-                            <option value="USD">$ U.S. Dollar</option>
-                            <option value="GBP">£ Pound Sterling</option>
-                        </optgroup>
-                    </select>
-                </div>
-                <input type="submit" asp-page-handler="Latest" value="Convert" />
-            </fieldset>
-        </form>
-    </div>
-</div>
-<div class="card">
-    <div class="card-body">
-        <form id="historical-data" method="post" class="text-center">
-            <h2>Get historical exchange rates</h2>
-            <div class="form-group">
-                <h5>Select any date since 1999:</h5>
-                <input type="date" required asp-for="IndexViewModel.Date" min="1999-01-01" />
-            </div>
+            <h2>Get the latest exchange rates</h2>
             <div class="form-group">
                 <h5>Initial currency type:</h5>
-                <select class="select-one" required asp-for="IndexViewModel.InitialType">
+                <select required asp-for="IndexViewModel.InitialType">
                     <optgroup label="Initial Currency">
                         <option value="EUR">€ Euro</option>
                         <option value="USD">$ U.S. Dollar</option>
@@ -66,7 +28,43 @@
             </div>
             <div class="form-group">
                 <h5>Return currency type:</h5>
-                <select class="select-two" required asp-for="IndexViewModel.ReturnType">
+                <select required asp-for="IndexViewModel.ReturnType">
+                    <optgroup label="Return Currency">
+                        <option value="EUR">€ Euro</option>
+                        <option value="USD">$ U.S. Dollar</option>
+                        <option value="GBP">£ Pound Sterling</option>
+                    </optgroup>
+                </select>
+            </div>
+            <input type="submit" asp-page-handler="Latest" value="Convert" />
+        </form>
+    </div>
+</div>
+<div class="card">
+    <div class="card-body">
+        <form id="historical-data" method="post" class="text-center">
+            <h2>Get historical exchange rates</h2>
+            <div class="form-group">
+                <h5>Select any date since 1999:</h5>
+                <input type="date" required asp-for="IndexViewModel.Date" min="1999-01-01" />
+            </div>
+            <div class="form-group">
+                <h5>Initial currency type:</h5>
+                <select required asp-for="IndexViewModel.InitialType">
+                    <optgroup label="Initial Currency">
+                        <option value="EUR">€ Euro</option>
+                        <option value="USD">$ U.S. Dollar</option>
+                        <option value="GBP">£ Pound Sterling</option>
+                    </optgroup>
+                </select>
+            </div>
+            <div class="form-group">
+                <h5>Amount to convert:</h5>
+                <input type="number" required asp-for="IndexViewModel.InitialAmount" min="0.01" step="0.01" />
+            </div>
+            <div class="form-group">
+                <h5>Return currency type:</h5>
+                <select required asp-for="IndexViewModel.ReturnType">
                     <optgroup label="Return Currency">
                         <option value="EUR">€ Euro</option>
                         <option value="USD">$ U.S. Dollar</option>

--- a/CurrencyExchange/Pages/Index.cshtml
+++ b/CurrencyExchange/Pages/Index.cshtml
@@ -11,32 +11,34 @@
 <div class="card">
     <div class="card-body">
         <form id="latest-data" method="post" class="text-center">
-            <h2>Get today's exchange rates</h2>
-            <div class="form-group">
-                <h5>Initial currency type:</h5>
-                <select required asp-for="IndexViewModel.InitialType">
-                    <optgroup label="Initial Currency">
-                        <option value="EUR">€ Euro</option>
-                        <option value="USD">$ U.S. Dollar</option>
-                        <option value="GBP">£ Pound Sterling</option>
-                    </optgroup>
-                </select>
-            </div>
-            <div class="form-group">
-                <h5>Amount to convert:</h5>
-                <input type="number" asp-for="IndexViewModel.InitialAmount" min="0.01" step="0.01" />
-            </div>
-            <div class="form-group">
-                <h5>Return currency type:</h5>
-                <select required asp-for="IndexViewModel.ReturnType">
-                    <optgroup label="Return Currency">
-                        <option value="EUR">€ Euro</option>
-                        <option value="USD">$ U.S. Dollar</option>
-                        <option value="GBP">£ Pound Sterling</option>
-                    </optgroup>
-                </select>
-            </div>
-            <input type="submit" value="Convert" />
+            <fieldset>
+                <legend><b>Get the latest exchange rates</b></legend>
+                <div class="form-group">
+                    <h5>Initial currency type:</h5>
+                    <select class="select-one" required asp-for="IndexViewModel.InitialType">
+                        <optgroup label="Initial Currency">
+                            <option value="EUR">€ Euro</option>
+                            <option value="USD">$ U.S. Dollar</option>
+                            <option value="GBP">£ Pound Sterling</option>
+                        </optgroup>
+                    </select>
+                </div>
+                <div class="form-group">
+                    <h5>Amount to convert:</h5>
+                    <input type="number" required asp-for="IndexViewModel.InitialAmount" min="0.01" step="0.01" />
+                </div>
+                <div class="form-group">
+                    <h5>Return currency type:</h5>
+                    <select class="select-two" required asp-for="IndexViewModel.ReturnType">
+                        <optgroup label="Return Currency">
+                            <option value="EUR">€ Euro</option>
+                            <option value="USD">$ U.S. Dollar</option>
+                            <option value="GBP">£ Pound Sterling</option>
+                        </optgroup>
+                    </select>
+                </div>
+                <input type="submit" asp-page-handler="Latest" value="Convert" />
+            </fieldset>
         </form>
     </div>
 </div>
@@ -46,8 +48,33 @@
             <h2>Get historical exchange rates</h2>
             <div class="form-group">
                 <h5>Select any date since 1999:</h5>
-                <input type="date" name="chosenDate" min="1999-01-01" />
+                <input type="date" required asp-for="IndexViewModel.Date" min="1999-01-01" />
             </div>
+            <div class="form-group">
+                <h5>Initial currency type:</h5>
+                <select class="select-one" required asp-for="IndexViewModel.InitialType">
+                    <optgroup label="Initial Currency">
+                        <option value="EUR">€ Euro</option>
+                        <option value="USD">$ U.S. Dollar</option>
+                        <option value="GBP">£ Pound Sterling</option>
+                    </optgroup>
+                </select>
+            </div>
+            <div class="form-group">
+                <h5>Amount to convert:</h5>
+                <input type="number" required asp-for="IndexViewModel.InitialAmount" min="0.01" step="0.01" />
+            </div>
+            <div class="form-group">
+                <h5>Return currency type:</h5>
+                <select class="select-two" required asp-for="IndexViewModel.ReturnType">
+                    <optgroup label="Return Currency">
+                        <option value="EUR">€ Euro</option>
+                        <option value="USD">$ U.S. Dollar</option>
+                        <option value="GBP">£ Pound Sterling</option>
+                    </optgroup>
+                </select>
+            </div>
+            <input type="submit" asp-page-handler="Historical" value="Convert" />
         </form>
     </div>
 </div>

--- a/CurrencyExchange/Pages/Index.cshtml.cs
+++ b/CurrencyExchange/Pages/Index.cshtml.cs
@@ -27,9 +27,15 @@ namespace CurrencyExchange.Pages
             
         }
 
-        public async Task<IActionResult> OnPost()
+        public async Task<IActionResult> OnPostLatest()
         {
             ExchangeData data = await exchangeService.GetExchangeDataAsync(IndexViewModel.InitialAmount, IndexViewModel.InitialType, IndexViewModel.ReturnType);
+            return RedirectToPage("Convert", "Convert", data);
+        }
+
+        public async Task<IActionResult> OnPostHistorical()
+        {
+            ExchangeData data = await exchangeService.GetExchangeDataAsync(IndexViewModel.InitialAmount, IndexViewModel.InitialType, IndexViewModel.ReturnType, IndexViewModel.Date);
             return RedirectToPage("Convert", "Convert", data);
         }
 


### PR DESCRIPTION
Historical functionality works


### Changes:
- Changed how the query string is constructed in CurrencyExchangeService based on whether or not a historical date is given by the user
- Added a DateTime property to ExchangeData since a date is returned in the JSON regardless of whether the latest or historical data is requested.
- The GetExchangeDataAsync method in ICurrencyExchangeService can now accept a nullable DateTime parameter
- Added a unit test for historical data (more tests needed? probably? but maybe not?)
- Nullable DateTime property also added to IndexViewModel
- Convert.cshtml now shows the date for the requested data
- Index.cshtml.cs now implements two discrete OnPost methods, "Latest" and "Historical" for the respective requests

- Resolves #5 
- Resolves #8 